### PR TITLE
Prevent access through Netlify domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[[redirects]]
+from = "https://skypilot.netlify.app/*"
+to = "https://www.skypilot.dev/:splat"
+status = "301"
+# Do this redirect even if the page exists
+force = true


### PR DESCRIPTION
## Context

The changes prevent access to the site through the Netlify domain.

## Changes

### User features ☑️

* Requests to the Netlify domain are now forwarded to the primary domain

## Testing 🔬

### Automated tests 🤖

* [x] `yarn run check-code` to do typechecking & linting and run standalone tests

### Manual tests 💪🏼

* [ ] Visit https://skypilot.netlify.app. Verify that the browser redirects to https://www.skypilot.dev

---

Reviews required: 0
