### PR TITLE
Forward Netlify default subdomain to primary domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ yarn-error.log*
 
 # Allow .gitkeep to prevent otherwise empty directories from being deleted
 !.gitkeep
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
 from = "https://skypilot.netlify.app/*"
 to = "https://www.skypilot.dev/:splat"
-status = "301"
+status = 301
 # Do this redirect even if the page exists
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[[redirects]]
+from = "https://skypilot.netlify.app/*"
+to = "https://www.skypilot.dev/:splat"
+status = "301"
+# Do this redirect even if the page exists
+force = true


### PR DESCRIPTION
## Context

The changes were made to prevent access to the website through the Netlify default subdomain. All requests to that subdomain are now redirected (with a 301 Moved Permanently response) to the primary domain.

## Changes

### User features ☑️

* Traffic to the Netlify default subdomain is now redirected to the primary domain.

### Dev fixes 🐞

* The initial attempt to configure the redirect in `netlify.toml` failed: all deployments using that config were broken, returning only a 500 Internal Server Error. The redirects were moved to the `_redirects` file as a workaround.

### Automated tests 🤖

* [ ] `yarn run check-code` to do typechecking & linting and run standalone tests

### Manual tests 💪🏼

* [ ] Verify that the deploy preview works correctly (specifically, that the 500 Internal Server Error has been resolved)

---

Reviews required: 0
