### PR TITLE
Sky-45: String value for status breaks redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ yarn-error.log*
 
 # Allow .gitkeep to prevent otherwise empty directories from being deleted
 !.gitkeep
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
 from = "https://skypilot.netlify.app/*"
 to = "https://www.skypilot.dev/:splat"
-status = "301"
+status = 301
 # Do this redirect even if the page exists
 force = true


### PR DESCRIPTION
Attempted fix: Changed string value `'301'` to numeric `301`.